### PR TITLE
Fixed collapsed icon not rotating when collapsed

### DIFF
--- a/features/layout/sidebar-navigation/sidebar-navigation.module.scss
+++ b/features/layout/sidebar-navigation/sidebar-navigation.module.scss
@@ -139,3 +139,7 @@
     display: flex;
   }
 }
+
+.rotatedIcon {
+  transform: rotate(180deg);
+}

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -90,7 +90,9 @@ export function SidebarNavigation() {
               iconSrc="/icons/arrow-left.svg"
               isCollapsed={isSidebarCollapsed}
               onClick={() => toggleSidebar()}
-              className={styles.collapseMenuItem}
+              className={classNames(styles.collapseMenuItem, {
+                [styles.rotatedIcon]: isSidebarCollapsed,
+              })}
             />
           </ul>
         </nav>


### PR DESCRIPTION
Previously, when a user collapsed the nav bar, the icon for the nav bar would still point left. Now, when the bar is collapsed, the nav bar points to the right. This is the direction the UI will move in when a user clicks on the collapsed icon.